### PR TITLE
Enhance hamburger menu animations

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -77,12 +77,27 @@ body.other-page nav.navbar .menu-toggle {
   background: transparent;
   border: none;
   cursor: pointer;
+  padding: 0;
+  transition: transform 0.3s ease;
 }
 
 body.other-page nav.navbar .menu-toggle span {
   width: 24px;
   height: 2px;
   background-color: #333;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+body.other-page nav.navbar .menu-toggle.active span:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+body.other-page nav.navbar .menu-toggle.active span:nth-child(2) {
+  opacity: 0;
+}
+
+body.other-page nav.navbar .menu-toggle.active span:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
 }
 
 
@@ -410,14 +425,22 @@ html, body {
     background-color: rgba(255, 255, 255, 0.12);
     backdrop-filter: blur(10px);
     border-radius: 1rem;
-    padding: 1rem;
-    display: none;
+    padding: 0 1rem;
+    display: flex;
     flex-direction: column;
     align-items: flex-start;
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    pointer-events: none;
+    transition: max-height 0.4s ease, opacity 0.4s ease, padding 0.4s ease;
   }
 
   body.other-page nav.navbar .nav-wrapper.open {
-    display: flex;
+    padding: 1rem;
+    max-height: 500px;
+    opacity: 1;
+    pointer-events: auto;
   }
 
   body.other-page nav.navbar ul.nav-links {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -26,12 +26,17 @@ document.addEventListener("DOMContentLoaded", function () {
   if (menuToggle && navWrapper) {
     menuToggle.addEventListener('click', () => {
       navWrapper.classList.toggle('open');
+      menuToggle.classList.toggle('active');
     });
   }
   if (navLinks.length) {
     navLinks.forEach(link => {
       link.addEventListener("click", function (e) {
         e.preventDefault();
+        if (navWrapper.classList.contains('open')) {
+          navWrapper.classList.remove('open');
+          menuToggle.classList.remove('active');
+        }
         const currentPage = window.location.pathname.split("/").pop();
         const targetPage = this.getAttribute("href");
 


### PR DESCRIPTION
## Summary
- animate hamburger toggle into a close icon
- smooth mobile navigation slide-down
- close menu after navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880f8e0dfd8832f92c7ff361834af8c