### PR TITLE
Fix contact page layout padding

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -55,7 +55,7 @@
       align-items: stretch;
       flex-wrap: nowrap;
       gap: 2rem;
-      padding: 5vh 10vw;
+      padding: 5vh clamp(2rem, 6vw, 6rem);
       width: 100%;
       max-width: 1400px;
       margin: 0 auto;


### PR DESCRIPTION
## Summary
- adjust `contact-container` padding to avoid shrinkage on large screens

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68839198e180832f83c6a119cfa0f311