### PR TITLE
Fix contact page alignment on large screens

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -51,7 +51,7 @@
   <style>
     .contact-container {
       display: flex;
-      justify-content: space-between;
+      justify-content: center;
       align-items: stretch;
       flex-wrap: nowrap;
       gap: 2rem;


### PR DESCRIPTION
## Summary
- center contact blocks instead of spreading them across the entire width on larger screens

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6883980a3078832f83fbcf38949f207e