### PR TITLE
Improve mobile spacing for project slider

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -187,6 +187,11 @@ body.other-page {
   opacity: 0;
   animation: fadeInUp 0.8s ease forwards;
 }
+.project-section {
+  padding: 5vh 5vw;
+  color: white;
+}
+
 /* Frosted content card styling for grid display */
 .frosted-block {
   backdrop-filter: blur(16px);
@@ -446,4 +451,17 @@ html, body {
   .frosted-block {
     flex: 1 1 100%;
   }
+  /* Reduced spacing for project page on small screens */
+  .page-projects .scrollable-content {
+    padding: 1rem;
+    gap: 1rem;
+  }
+  .page-projects section {
+    padding: 2vh 3vw;
+  }
+  .page-projects .frosted-block {
+    padding: 1rem 1.5rem;
+    margin-bottom: 1rem;
+  }
+
 }

--- a/projects.html
+++ b/projects.html
@@ -26,7 +26,7 @@
   </nav>
 <div class="scrollable-content">
   <main style="margin-top: 6vh;">
-    <section style="padding: 5vh 5vw; color: white;">
+    <section class="project-section">
       <div class="frosted-block" style="width: 100%; margin: 0 auto;">
         <h2 style="margin-top: 1rem; font-size: 2rem;">Algorithm Mirror</h2>
         <p style="font-size: 1.2rem;">


### PR DESCRIPTION
## Summary
- remove inline padding from the project page section
- add `.project-section` style
- tighten project page spacing on small screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883a1c03e88832fad8d2095cd47ac51